### PR TITLE
Set RefreshPolicy parameter to the ElasticRestTemplate copy 

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
@@ -70,6 +70,7 @@ import org.springframework.util.Assert;
  * @author Roman Puchkovskiy
  * @author Subhobrata Dey
  * @author Steven Pearce
+ * @author Anton Naydenov
  */
 public abstract class AbstractElasticsearchTemplate implements ElasticsearchOperations, ApplicationContextAware {
 
@@ -110,6 +111,7 @@ public abstract class AbstractElasticsearchTemplate implements ElasticsearchOper
 		}
 
 		copy.setRoutingResolver(routingResolver);
+		copy.setRefreshPolicy(refreshPolicy);
 
 		return copy;
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/core/routing/ElasticsearchOperationsRoutingTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/routing/ElasticsearchOperationsRoutingTests.java
@@ -33,11 +33,9 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Routing;
 import org.springframework.data.elasticsearch.annotations.Setting;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.IndexOperations;
-import org.springframework.data.elasticsearch.core.MultiGetItem;
-import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.*;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.elasticsearch.core.query.BaseQuery;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchRestTemplateConfiguration;
@@ -47,6 +45,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Anton Naydenov
  */
 @SuppressWarnings("ConstantConditions")
 @SpringIntegrationTest
@@ -157,6 +156,21 @@ public class ElasticsearchOperationsRoutingTests {
 		softly.assertThat(multiGetItems.get(1).hasItem()).isTrue();
 		softly.assertThat(multiGetItems.get(2).hasItem()).isTrue();
 		softly.assertAll();
+	}
+
+	@Test
+	void shouldCreateACopyOfTheClientWithRefreshPolicy() {
+		//given
+		AbstractElasticsearchTemplate sourceTemplate = (AbstractElasticsearchTemplate) operations;
+		SimpleElasticsearchMappingContext mappingContext = new SimpleElasticsearchMappingContext();
+		DefaultRoutingResolver defaultRoutingResolver = new DefaultRoutingResolver(mappingContext);
+
+		//when
+		ElasticsearchOperations operationsCopy = this.operations.withRouting(defaultRoutingResolver);
+		AbstractElasticsearchTemplate copyTemplate = (AbstractElasticsearchTemplate) operationsCopy;
+
+		//then
+		assertThat(sourceTemplate.getRefreshPolicy()).isEqualTo(copyTemplate.getRefreshPolicy());
 	}
 
 	@Document(indexName = INDEX)


### PR DESCRIPTION
Added transfer of parameter RefreshPolicy to the copy of Elastic template when calling method .withRouting(...) or .copy(...).

Closes #
